### PR TITLE
[Fix]: Make Continuation Grant Parameter `interact_ref` Optional

### DIFF
--- a/lib/Services/GrantService.php
+++ b/lib/Services/GrantService.php
@@ -98,9 +98,6 @@ class GrantService implements GrantRoutes
         if (! isset($requestParams['url']) || ! isset($requestParams['access_token'])) {
             throw new \InvalidArgumentException('Missing required data');
         }
-        if (! isset($grantRequest['interact_ref'])) {
-            throw new \InvalidArgumentException('Missing interact_ref in grantRequest');
-        }
         if (strpos($requestParams['url'], 'continue/') === false) {
             throw new \InvalidArgumentException('Invalid continuation grant URL');
         }

--- a/tests/Services/GrantServiceTest.php
+++ b/tests/Services/GrantServiceTest.php
@@ -105,19 +105,13 @@ class GrantServiceTest extends TestCase
         $this->service->continue(['access_token' => 'EAB18A53A6F67F9F1247'], ['interact_ref' => 'ref']);
     }
 
-    public function test_continue_throws_if_missing_interact_ref(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->service->continue(['url' => 'https://ilp.interledger-test.dev/continue/', 'access_token' => 'EAB18A53A6F67F9F1247'], []);
-    }
-
     public function test_continue_throws_if_invalid_url(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->service->continue(['url' => 'https://ilp.interledger-test.dev/not-continue/'], ['interact_ref' => 'ref']);
     }
 
-    public function test_continue_returns_grant(): void
+    public function test_continue_returns_grant_with_interact_ref(): void
     {
         $response = ['access_token' => 'xyz'];
         $this->apiClient
@@ -135,6 +129,28 @@ class GrantServiceTest extends TestCase
             'url' => 'https://ilp.interledger-test.dev/continue/abc',
             'access_token' => 'EAB18A53A6F67F9F1247',
         ], ['interact_ref' => 'xyz']);
+
+        $this->assertInstanceOf(Grant::class, $result);
+    }
+
+    public function test_continue_returns_grant_without_interact_ref(): void
+    {
+        $response = ['access_token' => 'xyz'];
+        $this->apiClient
+            ->expects($this->once())
+            ->method('request')
+            ->willReturn($response);
+
+        $this->grantTransformer
+            ->expects($this->once())
+            ->method('createFromResponse')
+            ->with($response)
+            ->willReturn($this->createMock(Grant::class));
+
+        $result = $this->service->continue([
+            'url' => 'https://ilp.interledger-test.dev/continue/abc',
+            'access_token' => 'EAB18A53A6F67F9F1247',
+        ], []);
 
         $this->assertInstanceOf(Grant::class, $result);
     }


### PR DESCRIPTION
This PR fixes issue #5 by making the `interact_ref` parameter optional in continuation grant requests, bringing the PHP library in line with the Node.js implementation and Open Payments specification.

## Problem

Previously, the PHP library required the `interact_ref` parameter to be present when calling the `continue()` method for grant continuation. This was enforced by a validation check in `GrantService.php` that threw an `InvalidArgumentException` if the parameter was missing.

However, the Node.js Open Payments library treats `interact_ref` as an optional parameter, allowing for more flexible usage patterns. According to the Open Payments specification, while `interact_ref` is typically used for interactive grants after user consent, there are scenarios where continuation might not require it.

## Changes Made

### Code Changes

1. **`lib/Services/GrantService.php`** (lines 96-106)
   - Removed the validation check that enforced `interact_ref` as mandatory
   - The parameter can now be omitted or passed as an empty array
   - Maintained all other validation checks (URL and access_token requirements) 

### Test Changes

2. **`tests/Services/GrantServiceTest.php`**
   - **Removed**: `test_continue_throws_if_missing_interact_ref()` - This test expected an exception when `interact_ref` was missing
   - **Renamed**: `test_continue_returns_grant()` → `test_continue_returns_grant_with_interact_ref()` - For clarity
   - **Added**: `test_continue_returns_grant_without_interact_ref()` - New test verifying continuation works without `interact_ref`

## Testing

All tests pass successfully:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b204ddf3-97be-4da0-945a-7bc7a0c405a3" />

The new test specifically validates that grant continuation works without the `interact_ref` parameter, ensuring backward compatibility while adding the flexibility needed.

## Compatibility

This change maintains backward compatibility:

- Existing code passing `interact_ref` will continue to work as before
- New code can omit `interact_ref` when not needed
- The API signature remains unchanged

## Alignment with Node.js Library

The Node.js library uses the following pattern:

```typescript
const grant = await client.grant.continue(
  {
    accessToken: CONTINUE_ACCESS_TOKEN,
    url: CONTINUE_URI,
  },
  {
    interact_ref: interactRef, // Optional parameter
  }
);
```

With this change, the PHP library now supports the same flexibility:

```php
// With interact_ref (interactive grants)
$grant = $service->continue([
    'url' => 'https://example.com/continue/abc',
    'access_token' => 'token123',
], ['interact_ref' => 'xyz']);

// Without interact_ref (non-interactive or polling scenarios)
$grant = $service->continue([
    'url' => 'https://example.com/continue/abc',
    'access_token' => 'token123',
], []);
```

## Related Issues

Closes #5 :)

## Checklist

- [x] Code changes implemented
- [x] Tests updated and passing
- [x] Backward compatibility maintained
- [x] Aligned with Node.js library behavior
